### PR TITLE
fix(question): Handle no discription case

### DIFF
--- a/app/core/templates/core/helpers/question_text.html
+++ b/app/core/templates/core/helpers/question_text.html
@@ -8,8 +8,5 @@
     </button>
     <div class="desc">{{question.description|safe}}</div>
 {% else %}
-    {*
-    Explicitly no output in this case, as it's not really useful
     <span class="glyphicon glyphicon-info-sign desc-toggler no-desc" title="{%trans "no_question_description"%}"></span>
-    *}
 {% endif %}


### PR DESCRIPTION
Previously the code comment was rendered on the output page. Removing
the comment fixes this issue.

Related issue: https://github.com/adfinis-sygroup/freedomvote/issues/25

Before:
![screenshot from 2016-11-17 07-45-49](https://cloud.githubusercontent.com/assets/7458098/20379591/55f64b68-ac9d-11e6-943d-3b34ee2bce7e.png)

After:
![screenshot from 2016-11-17 07-51-49-crop](https://cloud.githubusercontent.com/assets/7458098/20379592/55f72b14-ac9d-11e6-8c8f-1e43b45bc119.png)
