### PR TITLE
fix(popover): trigger resize after toggle

### DIFF
--- a/app/core/static/js/candidates.js
+++ b/app/core/static/js/candidates.js
@@ -56,7 +56,9 @@ jQuery(function($) {
 
                   $('.detail').not(detail).hide(effect)
 
-                  detail.toggle(effect)
+                  detail.toggle(effect, function(e) {
+                    window.dispatchEvent(new Event('resize'));
+                  })
                 }
               }
             }


### PR DESCRIPTION
By explicitly triggering a resize event after the toggle, the final rendering of
the chart is triggered.

Relates issue: https://github.com/freedomvote/freedomvote/issues/30