### PR TITLE
Minimal bar in diagrams

### DIFF
--- a/app/core/static/js/candidates.js
+++ b/app/core/static/js/candidates.js
@@ -117,6 +117,7 @@ jQuery(function($) {
         },
         series: [{
           colorByPoint: true,
+          minPointLength: 3,
           data: data.detail.values
         }]
       })


### PR DESCRIPTION
Shows a 3px bar if the value is 0.

Resolves #7 

![image](https://cloud.githubusercontent.com/assets/1693858/21455149/3874edb8-c91e-11e6-8b45-182db220ebfd.png)
