### PR TITLE
feat(urls): provide initial edit page

### DIFF
--- a/app/core/templates/core/initial_edit.html
+++ b/app/core/templates/core/initial_edit.html
@@ -1,0 +1,11 @@
+{% extends 'index.html' %}
+
+{% block 'content' %}
+<h1>Freedomvote is working!</h1>
+<p>You getting redirected here implies the basics of your Freedomvote deploy are working. Revert to the <a href="https://github.com/freedomvote/freedomvote/blob/master/README.md">documentation</a> to read up on how to configure your Freedomvote install.</p>
+<h2>Next steps</h2>
+<ul>
+    <li>Create new pages in the <a href="/admin">Django admin interface</a>.</li>
+    <li>Populate the Freedomvote information, using the commandline tools, the <a href="/admin">Django admin interface</a> or the dedicated dashboard for the parties.</li>
+</ul>
+{% endblock %}

--- a/app/core/urls.py
+++ b/app/core/urls.py
@@ -8,6 +8,11 @@ urlpatterns = patterns(
     # public urls
 
     '',
+    url(r'^(?P<lang>\w{2})/$',
+        # Default URL shown on first visit after install
+        views.initial_edit_view,
+        name='initial_edit'
+    ),
     url(
         r'^i18n/',
         include('django.conf.urls.i18n')

--- a/app/core/views.py
+++ b/app/core/views.py
@@ -3,6 +3,7 @@ from core.forms import PoliticianForm, PartyPoliticianForm
 from core.models import Politician, Question, State, Answer
 from core.models import Statistic, Category, Link
 from core.tools import set_cookie, get_cookie
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login, logout
 from django.contrib import messages
@@ -49,6 +50,15 @@ default_meta = Meta(
 ##
 # PUBLIC VIEWS
 ##
+
+
+def initial_edit_view(request, lang):
+    if settings.DEBUG:
+        response = render(request, 'core/initial_edit.html')
+    else:
+        response = render(request, '404.html')
+        response.status_code = 404
+    return response
 
 
 def candidates_view(request):


### PR DESCRIPTION
Provide a static page which is rendered on first login.

Other solutions were suggested (redirect to other page, database population with
Django CMS page). This seemed a very straightforward and friendly solution.

The page is only shown in case the DEBUG setting is True, otherwise a 404 is returned.

Associated issue: https://github.com/freedomvote/freedomvote/issues/33