### PR TITLE
feat: static placeholder in footer

### DIFF
--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -1,6 +1,7 @@
-{% load staticfiles i18n helpers %}
+{% load cms_tags staticfiles i18n helpers %}
 
 <footer class="footer">
+    {% static_placeholder 'footer' %}
     <div class="center-content">
         <div class="col-md-2">
             <a class="footer-icon" href="{% url 'info' %}">


### PR DESCRIPTION
This change adds a static placeholder on the footer, such that the contents of the footer can more easily be changed. Related issue: https://github.com/freedomvote/freedomvote/issues/74

There is no surrounding `<div>` around the contents, which provides much freedom, but requires the editor to use the style elements known by Bootstrap.js.

Example:
![screenshot from 2017-01-30 07-14-50](https://cloud.githubusercontent.com/assets/7458098/22413978/69d29476-e6bc-11e6-93f9-417f29c95469.png)
![screenshot from 2017-01-30 07-15-22](https://cloud.githubusercontent.com/assets/7458098/22413977/69d08212-e6bc-11e6-9816-642727de1592.png)
