### PR TITLE
Added information about more dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Requirements:
 
 * python 2.7
 * postgresql
+* libjpeg
+* zlib
 * python-pip
 
 Run `pip install -r requirements.txt` to install all requirements.


### PR DESCRIPTION
Pillow (installed via requirements.txt) depends on both libjpeg and
zlib.