### PR TITLE
Fix politician import script

### DIFF
--- a/app/core/management/commands/politician_import.py
+++ b/app/core/management/commands/politician_import.py
@@ -15,7 +15,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         try:
             with open(options['json_file']) as f:
-                try:
                 data = json.load(f)
 
                 for row in data:


### PR DESCRIPTION
The last refactor of politician_import.py introduced a bug that
renders it unuseable. This simple patch fixes it.