### PR TITLE
Change requirement from python 2.7 to 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is how Freedomvote looked for the Swiss Election in 2015 - [freedomvote.ch]
 ## The "hard" way
 Requirements:
 
-* python 2.7
+* python 3
 * postgresql
 * libjpeg
 * zlib


### PR DESCRIPTION
At least manage.py depends on python 3, so bumping the information
about the required python version on README.