### PR TITLE
Remove django cms language cookie

### DIFF
--- a/app/freedomvote/settings.py
+++ b/app/freedomvote/settings.py
@@ -133,7 +133,6 @@ MIDDLEWARE_CLASSES = (
     'cms.middleware.user.CurrentUserMiddleware',
     'cms.middleware.page.CurrentPageMiddleware',
     'cms.middleware.toolbar.ToolbarMiddleware',
-    'cms.middleware.language.LanguageCookieMiddleware'
 )
 
 TEMPLATES = [

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -46,11 +46,13 @@
                 <input name="language" type="hidden" value="{{ language.code }}" />
                 <ul class="navbar-nav nav">
                 {% for language in languages %}
-                    <li><a href="#" data-lang="{{language.code}}">
-                        {% if language.code == LANGUAGE_CODE %}<strong>{% endif %}
-                        {{language.code|upper}}
-                        {% if language.code == LANGUAGE_CODE %}</strong>{% endif %}
-                    </a></li>
+                    <li>
+                        <a href="#" data-lang="{{language.code}}">
+                          {% if language.code == LANGUAGE_CODE %}<strong>{% endif %}
+                          {{language.code|upper}}
+                          {% if language.code == LANGUAGE_CODE %}</strong>{% endif %}
+                        </a>
+                    </li>
                 {% endfor %}
                 </ul>
             </form>


### PR DESCRIPTION
It's not necessary to support several languages in the django cms. Especially it causes that the language of the website can't be changed.