### PR TITLE
fix(startup): make docker-compose work again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.6
 ENV PYTHONUNBUFFERED 1
 
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
-&& apt-get update && apt-get install -y gettext postgresql-client nodejs npm\
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+&& apt-get update && apt-get install -y gettext postgresql-client nodejs \
 && wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -P /usr/bin \
 && chmod +x /usr/bin/wait-for-it.sh
 

--- a/tools/docker/cache_table.sql
+++ b/tools/docker/cache_table.sql
@@ -4,11 +4,6 @@ CREATE TABLE cache_table (
     expires timestamp with time zone NOT NULL
 );
 
-ALTER TABLE cache_table OWNER TO postgres;
-
-COPY cache_table (cache_key, value, expires) FROM stdin;
-\.
-
 ALTER TABLE ONLY cache_table
     ADD CONSTRAINT cache_table_pkey PRIMARY KEY (cache_key);
 


### PR DESCRIPTION
The node dependency was so old it didn't boot anymore. Also, Postgres
wasn't happy with the cache_table setup, so removing unneeded parts of the
sql script for now.